### PR TITLE
Fix the 64-bit build

### DIFF
--- a/src/d/wiz/compile/bank.d
+++ b/src/d/wiz/compile/bank.d
@@ -10,7 +10,7 @@ class Bank
         enum ubyte PadValue = 0xFF;
 
         // The index of this bank, used by debug symbols.
-        int index;
+        size_t index;
         // The name of this bank.
         string name;
         // Until a ROM relocation occurs, this page is not initialized.


### PR DESCRIPTION
When we inconsistently use 'index' as a size_t (e.g. in the constructor)
and as an int (e.g. in the definition of class Bank), dmd complains about
implicit conversions between non-equivalent types on 64-bit. The types are
non-equivalent because, on a 64-bit build, size_t is a ulong, which is a
different size from int.

  src/d/wiz/compile/bank.d(69): Error: cannot implicitly convert expression
  (index) of type ulong to int

Fix the build by being consistent with the type of 'index' by always using
size_t.
