### PR TITLE
Remove unused parameter to fix Mac build

### DIFF
--- a/src/wiz/utility/unique_ptr.h
+++ b/src/wiz/utility/unique_ptr.h
@@ -189,7 +189,7 @@ namespace wiz {
 namespace std {
     template <typename T, typename Deleter>
     struct hash<wiz::UniquePtr<T, Deleter>> {
-        WIZ_FORCE_INLINE std::size_t operator()(const wiz::UniquePtr<T, Deleter>& ptr) const {
+        WIZ_FORCE_INLINE std::size_t operator()(const wiz::UniquePtr<T, Deleter>&) const {
             return std::hash<typename wiz::UniquePtr<T, Deleter>::PointerType>();
         }
     };


### PR DESCRIPTION
Hello Andrew,

Please forgive the sudden pull request. I cloned wiz today and found that it wouldn't compile on my Mac. It's an error on the Mac to declare a parameter and not use it.

If you'd prefer, I could modify the Makefile to make this not throw an error.

Thanks for wiz. I haven't had enough time to build anything large in it, but I'm planning out a couple projects with it.