### PR TITLE
Add missing #include to fix MinGW build

### DIFF
--- a/src/wiz/utility/misc.cpp
+++ b/src/wiz/utility/misc.cpp
@@ -1,5 +1,7 @@
 #include <wiz/utility/misc.h>
 
+#include <limits>
+
 namespace wiz {
     std::size_t log2(std::size_t value) {
         std::size_t result = 0;


### PR DESCRIPTION
std::numeric_limits needs \<limits\>, won't build otherwise.