### PR TITLE
Test Z80 calls

### DIFF
--- a/tests/block/z80_func_call.wiz
+++ b/tests/block/z80_func_call.wiz
@@ -1,0 +1,29 @@
+// SYSTEM  z80
+
+import "_z80_memmap.wiz";
+
+// BLOCK 000000
+in prg {
+
+func first_function() {
+// BLOCK             c9                    ret
+}
+
+func call_test {
+// BLOCK             cd 00 00              call 0x0000
+    first_function();
+// BLOCK             c4 00 00              call nz, 0x0000
+    first_function() if !zero;
+// BLOCK             cc 00 00              call z, 0x0000
+    first_function() if zero;
+// BLOCK             d4 00 00              call nc, 0x0000
+    first_function() if !carry;
+// BLOCK             dc 00 00              call c, 0x0000
+    first_function() if carry;
+// BLOCK             c9                    ret
+}
+
+// BLOCK             ff
+
+}
+

--- a/tests/block/z80_func_tail_call.wiz
+++ b/tests/block/z80_func_tail_call.wiz
@@ -1,0 +1,40 @@
+// SYSTEM  z80
+
+import "_z80_memmap.wiz";
+
+// BLOCK 000000
+in prg {
+
+func first_function() {
+// BLOCK             c9                    ret
+}
+
+func tailcall_test {
+// BLOCK             18 fd                 jr 0x0000
+    return first_function();
+// BLOCK             20 fb                 jr nz, 0x0000
+    return first_function() if !zero;
+// BLOCK             28 f9                 jr z, 0x0000
+    return first_function() if zero;
+// BLOCK             30 f7                 jr nc, 0x0000
+    return first_function() if !carry;
+// BLOCK             38 f5                 jr c, 0x0000
+    return first_function() if carry;
+
+// BLOCK             c3 00 00              jp 0x0000
+    ^return first_function();
+// BLOCK             c2 00 00              jp nz, 0x0000
+    ^return first_function() if !zero;
+// BLOCK             ca 00 00              jp z, 0x0000
+    ^return first_function() if zero;
+// BLOCK             d2 00 00              jp nc, 0x0000
+    ^return first_function() if !carry;
+// BLOCK             da 00 00              jp c, 0x0000
+    ^return first_function() if carry;
+// BLOCK             c9                    ret
+}
+
+// BLOCK             ff
+
+}
+


### PR DESCRIPTION
## Test results for regular calls:
```
$ bash tests/wiztests.sh -w bin/wiz -b tests/bin/ tests/block/z80_func_call.wiz
Python 2.7.17
tests/block/z80_func_call.wiz:('bin/wiz', '--system', 'z80', '-o', 'tests/bin/z80_func_call.z80.bin', 'tests/block/z80_func_call.wiz')
 FAILED
	> bin/wiz --system z80 -o tests/bin/z80_func_call.z80.bin tests/block/z80_func_call.wiz
	wiz returned failure code 1 in a block test
	* wiz: version 0.1.2 (alpha)
	>> Parsing...
	tests/block/z80_func_call.wiz:16: error: expected `;` after previous statement, but got keyword `if` instead
	tests/block/z80_func_call.wiz:16: error: expected `{`, but got `;` instead
	tests/block/z80_func_call.wiz:18: error: expected `;` after previous statement, but got keyword `if` instead
	tests/block/z80_func_call.wiz:18: error: expected `{`, but got `;` instead
	tests/block/z80_func_call.wiz:20: error: expected `;` after previous statement, but got keyword `if` instead
	tests/block/z80_func_call.wiz:20: error: expected `{`, but got `;` instead
	tests/block/z80_func_call.wiz:22: error: expected `;` after previous statement, but got keyword `if` instead
	tests/block/z80_func_call.wiz:22: error: expected `{`, but got `;` instead
	tests/block/z80_func_call.wiz:29: error: expected `}` to close block `{`, but got end-of-file instead
	tests/block/z80_func_call.wiz:18: note: block `{` started here
	tests/block/z80_func_call.wiz:29: error: expected `}` to close block `{`, but got end-of-file instead
	tests/block/z80_func_call.wiz:16: note: block `{` started here
	tests/block/z80_func_call.wiz:29: error: expected `}` to close block `{`, but got end-of-file instead
	tests/block/z80_func_call.wiz:12: note: block `{` started here
	tests/block/z80_func_call.wiz:29: error: expected `}` to close block `{`, but got end-of-file instead
	tests/block/z80_func_call.wiz:6: note: block `{` started here
	* wiz: failed with 12 error(s).
	

0 tests passed
1 TESTS FAILED

```

## Test results for tail calls:
```
$ bash tests/wiztests.sh -w bin/wiz -b tests/bin/ tests/block/z80_func_tail_call.wiz 
Python 2.7.17
tests/block/z80_func_tail_call.wiz:('bin/wiz', '--system', 'z80', '-o', 'tests/bin/z80_func_tail_call.z80.bin', 'tests/block/z80_func_tail_call.wiz')
 FAILED
	> bin/wiz --system z80 -o tests/bin/z80_func_tail_call.z80.bin tests/block/z80_func_tail_call.wiz
	tests/bin/z80_func_tail_call.z80.bin 0x000003: expected 0x20 got 0x18
	tests/bin/z80_func_tail_call.z80.bin 0x000005: expected 0x28 got 0x18
	tests/bin/z80_func_tail_call.z80.bin 0x000007: expected 0x30 got 0x18
	tests/bin/z80_func_tail_call.z80.bin 0x000009: expected 0x38 got 0x18
	tests/bin/z80_func_tail_call.z80.bin 0x00000e: expected 0xc2 got 0xc3
	tests/bin/z80_func_tail_call.z80.bin 0x000011: expected 0xca got 0xc3
	+ 2 more incorrect bytes

0 tests passed
1 TESTS FAILED
```