### PR TITLE
fixed a loop condition in Bank::calculateUsedSize

### DIFF
--- a/src/wiz/compiler/bank.cpp
+++ b/src/wiz/compiler/bank.cpp
@@ -173,7 +173,7 @@ namespace wiz {
     }
 
     std::size_t Bank::calculateUsedSize() const {
-        for (std::size_t i = ownership.size() - 1; i < ownership.size(); --i) {
+        for (std::size_t i = ownership.size() - 1; i >= 0; --i) {
             if (ownership[i] != 0) {
                 return i + 1;
             }


### PR DESCRIPTION
Found a small bug in the `Bank::calculateUsedSize` loop condition. I don't think I need to describe the fix too much :)