### PR TITLE
Enable VSCode problem matcher

### DIFF
--- a/src/wiz/utility/source_location.cpp
+++ b/src/wiz/utility/source_location.cpp
@@ -28,8 +28,8 @@ namespace wiz {
     canonicalPath(expandedPath) {}
     
     std::string SourceLocation::toString() const {
-        return displayPath.getLength() != 0
-            ? displayPath.toString() + (line > 0 ? ":" + std::to_string(line) : "")
+        return canonicalPath.getLength() != 0
+            ? canonicalPath.toString() + (line > 0 ? ":" + std::to_string(line) : "")
             : "";
     }
 }


### PR DESCRIPTION
Because wiz returns errors with the file name without any regards to the folder structure, it's impossible to set up VSCode problem matcher.

This is just a suggestion, not a fix. If it's in, I'll be able to modify VSCode extension as well. Otherwise please let me know if you want it do be done differently.