### PR TITLE
Address the issue when absolute RAM addresses overlap with relative ROM

### DIFF
--- a/src/wiz/format/debug/mlb_debug_format.cpp
+++ b/src/wiz/format/debug/mlb_debug_format.cpp
@@ -68,7 +68,7 @@ namespace wiz {
             return ""_sv;
         }
 
-        void dumpAddress(Writer* writer, const Definition* definition, DebugFormatContext& context) {
+        void dumpAddress(Writer* writer, const Definition* definition, DebugFormatContext& context, MlbAddressOwnership& addressOwnership) {
             const auto outputContext = context.outputContext;
             const auto address = definition->getAddress();
 
@@ -104,11 +104,11 @@ namespace wiz {
                         : startValue;
 
                     for (std::size_t i = startValue; i <= endValue; i++) {
-                        const auto match = context.addressOwnership.find(i);
-                        if (match != context.addressOwnership.end()) {
+                        const auto match = addressOwnership.find({ i, labelTypes });
+                        if (match != addressOwnership.end()) {
                             return;
                         } else {
-                            context.addressOwnership[i] = definition;
+                            addressOwnership[{ i, labelTypes }] = definition;
                         }
                     }
 
@@ -149,11 +149,12 @@ namespace wiz {
     MlbDebugFormat::~MlbDebugFormat() {}
 
     bool MlbDebugFormat::generate(DebugFormatContext& context) {
+        MlbAddressOwnership addressOwnership;
         const auto debugName = path::stripExtension(context.outputName).toString() + ".mlb";
 
         if (auto writer = context.resourceManager->openWriter(StringView(debugName))) {
             for (const auto& definition : context.definitions) {
-                dumpAddress(writer.get(), definition, context);
+                dumpAddress(writer.get(), definition, context, addressOwnership);
             }
         }       
 

--- a/src/wiz/format/debug/mlb_debug_format.h
+++ b/src/wiz/format/debug/mlb_debug_format.h
@@ -4,6 +4,14 @@
 #include <wiz/format/debug/debug_format.h>
 
 namespace wiz {
+    typedef std::pair<std::size_t, StringView> OwnershipKey;
+    struct OwnershipKeyHash {
+        std::size_t operator() (const OwnershipKey& pair) const {
+            return std::hash<std::size_t>()(pair.first) ^ std::hash<StringView>()(pair.second);
+        }
+    };
+    typedef std::unordered_map<OwnershipKey, const Definition*, OwnershipKeyHash> MlbAddressOwnership;
+
     class MlbDebugFormat : public DebugFormat {
         public:
             MlbDebugFormat();


### PR DESCRIPTION
Because of the specifics of Mesen label files, where ROM labels are relative, there could be (and in my case was) a case where RAM variable absolute address (e.g. 0x600) overlaps with relative bank address (0x8600), which results in wiz not emitting label for whatever comes the second.

This fix ensures that address ownership is checked by label type, not just by address.

So... I don't _love_ this bugfix, but I'm also not C++ developer. Please feel free to give any feedback, and I can fix it better.

I know DebugFormatContext shares addressOwnership with other debug outputs, but I didn't feel it was appropriate to either change it, or add mlb specific one.