### PR TITLE
SPC700 fixes

### DIFF
--- a/src/wiz/platform/spc700_platform.cpp
+++ b/src/wiz/platform/spc700_platform.cpp
@@ -301,7 +301,7 @@ namespace wiz {
 
                 const auto base = static_cast<int>(bank->getAddress().absolutePosition.get());
                 const auto dest = static_cast<int>(captureLists[options.parameter[1]][0]->integer.value);
-                const auto offset = dest - base - 2;
+                const auto offset = dest - base - 3;
                 if (offset >= -128 && offset <= 127) {
                     buffer.push_back(offset < 0
                         ? (static_cast<std::uint8_t>(-offset) ^ 0xFF) + 1

--- a/src/wiz/platform/spc700_platform.cpp
+++ b/src/wiz/platform/spc700_platform.cpp
@@ -503,8 +503,8 @@ namespace wiz {
                 ArithmeticOperandSignature {patternA, patternDirectIndexedByXIndirectU8, encodingU8Operand, 0x07, {1}},
                 ArithmeticOperandSignature {patternA, patternDirectIndirectIndexedByYU8, encodingU8Operand, 0x17, {1}},
                 ArithmeticOperandSignature {patternXIndirectU8, patternYIndirectU8, encodingImplicit, 0x19, {0, 1}},
-                ArithmeticOperandSignature {patternDirectU8, patternImmU8, encodingU8OperandU8Operand, 0x09, {0, 1}},
-                ArithmeticOperandSignature {patternDirectU8, patternDirectU8, encodingU8OperandU8Operand, 0x18, {0, 1}},
+                ArithmeticOperandSignature {patternDirectU8, patternImmU8, encodingU8OperandU8Operand, 0x18, {1, 0}},
+                ArithmeticOperandSignature {patternDirectU8, patternDirectU8, encodingU8OperandU8Operand, 0x09, {1, 0}},
             };
             //  arithmetic (a, mem) and (mem, mem)
             for (const auto& op : arithmeticOperators) {
@@ -541,8 +541,8 @@ namespace wiz {
         builtins.createInstruction(InstructionSignature(BinaryOperatorKind::Assignment, 0, {patternX, patternSP}), encodingImplicit, InstructionOptions({0x9D}, {}, {}));
         builtins.createInstruction(InstructionSignature(BinaryOperatorKind::Assignment, 0, {patternSP, patternX}), encodingImplicit, InstructionOptions({0xBD}, {}, {}));
         // mem = mem
-        builtins.createInstruction(InstructionSignature(BinaryOperatorKind::Assignment, 0, {patternDirectU8, patternImmU8}), encodingU8OperandU8Operand, InstructionOptions({0xFA}, {0, 1}, {}));
-        builtins.createInstruction(InstructionSignature(BinaryOperatorKind::Assignment, 0, {patternDirectU8, patternDirectU8}), encodingU8OperandU8Operand, InstructionOptions({0x8F}, {0, 1}, {}));
+        builtins.createInstruction(InstructionSignature(BinaryOperatorKind::Assignment, 0, {patternDirectU8, patternImmU8}), encodingU8OperandU8Operand, InstructionOptions({0x8F}, {1, 0}, {}));
+        builtins.createInstruction(InstructionSignature(BinaryOperatorKind::Assignment, 0, {patternDirectU8, patternDirectU8}), encodingU8OperandU8Operand, InstructionOptions({0xFA}, {1, 0}, {}));
         // cmp x, mem
         builtins.createInstruction(InstructionSignature(InstructionType::VoidIntrinsic(cmp), 0, {patternX, patternImmU8}), encodingU8Operand, InstructionOptions({0xC8}, {1}, {}));
         builtins.createInstruction(InstructionSignature(InstructionType::VoidIntrinsic(cmp), 0, {patternX, patternDirectU8}), encodingU8Operand, InstructionOptions({0x3E}, {1}, {}));

--- a/src/wiz/platform/spc700_platform.cpp
+++ b/src/wiz/platform/spc700_platform.cpp
@@ -694,8 +694,8 @@ namespace wiz {
         builtins.createInstruction(InstructionSignature(BinaryOperatorKind::Assignment, 0, {patternDirectU8BitIndex, patternTrue}), encodingU8OperandBitIndex, InstructionOptions({0x10}, {0, 0, 1}, {}));
         // tclr1 abs
         // tset1 abs
-        builtins.createInstruction(InstructionSignature(InstructionType::VoidIntrinsic(test_and_clear), 0, {patternA, patternAbsoluteU8}), encodingU16Operand, InstructionOptions({0x0E}, {}, {}));
-        builtins.createInstruction(InstructionSignature(InstructionType::VoidIntrinsic(test_and_set), 0, {patternA, patternAbsoluteU8}), encodingU16Operand, InstructionOptions({0x4E}, {}, {}));
+        builtins.createInstruction(InstructionSignature(InstructionType::VoidIntrinsic(test_and_clear), 0, {patternA, patternAbsoluteU8}), encodingU16Operand, InstructionOptions({0x4E}, {1}, {}));
+        builtins.createInstruction(InstructionSignature(InstructionType::VoidIntrinsic(test_and_set), 0, {patternA, patternAbsoluteU8}), encodingU16Operand, InstructionOptions({0x0E}, {1}, {}));
         // carry &= mem$bit
         builtins.createInstruction(InstructionSignature(BinaryOperatorKind::BitwiseAnd, 0, {patternCarry, patternAbsoluteU8BitIndex}), encodingU13OperandBitIndex, InstructionOptions({0x4A}, {1, 1, 1}, {}));
         // carry &= !mem$bit

--- a/src/wiz/platform/spc700_platform.cpp
+++ b/src/wiz/platform/spc700_platform.cpp
@@ -580,7 +580,7 @@ namespace wiz {
             };
             for (const auto& op : shiftOperators) {
                 builtins.createInstruction(InstructionSignature(op.first, 0, {patternA, patternImmU8}), encodingRepeatedImplicit, InstructionOptions({static_cast<std::uint8_t>(op.second | 0x1C)}, {1}, {}));
-                builtins.createInstruction(InstructionSignature(op.first, 0, {patternDirectU8, patternImmU8}), encodingRepeatedU8Operand, InstructionOptions({static_cast<std::uint8_t>(op.second | 0x6B)}, {0, 1}, {}));
+                builtins.createInstruction(InstructionSignature(op.first, 0, {patternDirectU8, patternImmU8}), encodingRepeatedU8Operand, InstructionOptions({static_cast<std::uint8_t>(op.second | 0x0B)}, {0, 1}, {}));
                 builtins.createInstruction(InstructionSignature(op.first, 0, {patternDirectIndexedByXU8, patternImmU8}), encodingRepeatedU8Operand, InstructionOptions({static_cast<std::uint8_t>(op.second | 0x1B)}, {0, 1}, {}));
                 builtins.createInstruction(InstructionSignature(op.first, 0, {patternAbsoluteU8, patternImmU8}), encodingRepeatedU16Operand, InstructionOptions({static_cast<std::uint8_t>(op.second | 0x0C)}, {0, 1}, {}));
             }

--- a/src/wiz/platform/spc700_platform.cpp
+++ b/src/wiz/platform/spc700_platform.cpp
@@ -606,7 +606,7 @@ namespace wiz {
         builtins.createInstruction(InstructionSignature(BinaryOperatorKind::Multiplication, 0, {patternYA, patternY, patternA}), encodingImplicit, InstructionOptions({0xCF}, {}, {}));
         builtins.createInstruction(InstructionSignature(BinaryOperatorKind::Multiplication, 0, {patternYA, patternA, patternY}), encodingImplicit, InstructionOptions({0xCF}, {}, {}));
         // divmod(ya, x) // div ya, x -> y = result_mod, a = result_div
-        builtins.createInstruction(InstructionSignature(InstructionType::VoidIntrinsic(divmod), 0, {patternYA, patternX}), encodingU8Operand, InstructionOptions({0x9E}, {1}, {}));
+        builtins.createInstruction(InstructionSignature(InstructionType::VoidIntrinsic(divmod), 0, {patternYA, patternX}), encodingImplicit, InstructionOptions({0x9E}, {}, {}));
         // daa
         // das
         builtins.createInstruction(InstructionSignature(InstructionType::VoidIntrinsic(decimal_adjust_add), 0, {}), encodingImplicit, InstructionOptions({0xDF}, {}, {}));

--- a/src/wiz/platform/spc700_platform.cpp
+++ b/src/wiz/platform/spc700_platform.cpp
@@ -23,6 +23,7 @@ namespace wiz {
     void Spc700Platform::reserveDefinitions(Builtins& builtins) {
 		// http://emureview.ztnet.com/developerscorner/SoundCPU/spc.htm
 		// https://wiki.superfamicom.org/spc700-reference
+		// https://snes.nesdev.org/wiki/SPC-700_instruction_set
 
         builtins.addDefineBoolean("__cpu_spc700"_sv, true);
 

--- a/src/wiz/platform/spc700_platform.cpp
+++ b/src/wiz/platform/spc700_platform.cpp
@@ -554,14 +554,14 @@ namespace wiz {
         // increment
         builtins.createInstruction(InstructionSignature(UnaryOperatorKind::PreIncrement, 0, {patternA}), encodingImplicit, InstructionOptions({0xBC}, {0}, {zero}));
         builtins.createInstruction(InstructionSignature(UnaryOperatorKind::PreIncrement, 0, {patternDirectU8}), encodingU8Operand, InstructionOptions({0xAB}, {0}, {zero}));
-        builtins.createInstruction(InstructionSignature(UnaryOperatorKind::PreIncrement, 0, {patternDirectIndexedByXU8}), encodingU16Operand, InstructionOptions({0xBB}, {0}, {zero}));
+        builtins.createInstruction(InstructionSignature(UnaryOperatorKind::PreIncrement, 0, {patternDirectIndexedByXU8}), encodingU8Operand, InstructionOptions({0xBB}, {0}, {zero}));
         builtins.createInstruction(InstructionSignature(UnaryOperatorKind::PreIncrement, 0, {patternAbsoluteU8}), encodingU16Operand, InstructionOptions({0xAC}, {0}, {zero}));
         builtins.createInstruction(InstructionSignature(UnaryOperatorKind::PreIncrement, 0, {patternX}), encodingImplicit, InstructionOptions({0x3D}, {}, {zero}));
         builtins.createInstruction(InstructionSignature(UnaryOperatorKind::PreIncrement, 0, {patternY}), encodingImplicit, InstructionOptions({0xFC}, {}, {zero}));
         // decrement
         builtins.createInstruction(InstructionSignature(UnaryOperatorKind::PreDecrement, 0, {patternA}), encodingImplicit, InstructionOptions({0x9C}, {0}, {zero}));
         builtins.createInstruction(InstructionSignature(UnaryOperatorKind::PreDecrement, 0, {patternDirectU8}), encodingU8Operand, InstructionOptions({0x8B}, {0}, {zero}));
-        builtins.createInstruction(InstructionSignature(UnaryOperatorKind::PreDecrement, 0, {patternDirectIndexedByXU8}), encodingU16Operand, InstructionOptions({0x9B}, {0}, {zero}));
+        builtins.createInstruction(InstructionSignature(UnaryOperatorKind::PreDecrement, 0, {patternDirectIndexedByXU8}), encodingU8Operand, InstructionOptions({0x9B}, {0}, {zero}));
         builtins.createInstruction(InstructionSignature(UnaryOperatorKind::PreDecrement, 0, {patternAbsoluteU8}), encodingU16Operand, InstructionOptions({0x8C}, {0}, {zero}));
         builtins.createInstruction(InstructionSignature(UnaryOperatorKind::PreDecrement, 0, {patternX}), encodingImplicit, InstructionOptions({0x1D}, {}, {zero}));
         builtins.createInstruction(InstructionSignature(UnaryOperatorKind::PreDecrement, 0, {patternY}), encodingImplicit, InstructionOptions({0xDC}, {}, {zero}));

--- a/src/wiz/platform/spc700_platform.cpp
+++ b/src/wiz/platform/spc700_platform.cpp
@@ -329,7 +329,7 @@ namespace wiz {
                 const auto zp = static_cast<std::uint8_t>(captureLists[options.parameter[0]][0]->integer.value);
                 const auto n = static_cast<std::uint8_t>(captureLists[options.parameter[1]][options.parameter[2]]->integer.value);
                 buffer.insert(buffer.end(), options.opcode.begin(), options.opcode.end());
-                buffer[buffer.size() - 1] |= static_cast<std::uint8_t>(n << 4);
+                buffer[buffer.size() - 1] |= static_cast<std::uint8_t>(n << 5);
                 buffer.push_back(zp);
                 return true;
             });
@@ -690,8 +690,8 @@ namespace wiz {
         builtins.createInstruction(InstructionSignature(BinaryOperatorKind::Assignment, 0, {patternInterrupt, patternTrue}), encodingImplicit, InstructionOptions({0xA0}, {}, {}));
         // clr1 dp$bit
         // set1 dp$bit
-        builtins.createInstruction(InstructionSignature(BinaryOperatorKind::Assignment, 0, {patternDirectU8BitIndex, patternFalse}), encodingU8OperandBitIndex, InstructionOptions({0x00}, {0, 0, 1}, {}));
-        builtins.createInstruction(InstructionSignature(BinaryOperatorKind::Assignment, 0, {patternDirectU8BitIndex, patternTrue}), encodingU8OperandBitIndex, InstructionOptions({0x10}, {0, 0, 1}, {}));
+        builtins.createInstruction(InstructionSignature(BinaryOperatorKind::Assignment, 0, {patternDirectU8BitIndex, patternFalse}), encodingU8OperandBitIndex, InstructionOptions({0x12}, {0, 0, 1}, {}));
+        builtins.createInstruction(InstructionSignature(BinaryOperatorKind::Assignment, 0, {patternDirectU8BitIndex, patternTrue}), encodingU8OperandBitIndex, InstructionOptions({0x02}, {0, 0, 1}, {}));
         // tclr1 abs
         // tset1 abs
         builtins.createInstruction(InstructionSignature(InstructionType::VoidIntrinsic(test_and_clear), 0, {patternA, patternAbsoluteU8}), encodingU16Operand, InstructionOptions({0x4E}, {1}, {}));

--- a/src/wiz/platform/spc700_platform.cpp
+++ b/src/wiz/platform/spc700_platform.cpp
@@ -215,12 +215,13 @@ namespace wiz {
                     UnaryOperatorKind::PostIncrement,
                     patternX->clone())),
                 1));
-        const auto patternAbsoluteIndexedByXIndirectU16
-            = builtins.createInstructionOperandPattern(InstructionOperandPattern::Dereference(
+        const auto patternIndirectJumpIndexedByX
+            = builtins.createInstructionOperandPattern(InstructionOperandPattern::Index(
                 false,
                 makeFwdUnique<InstructionOperandPattern>(InstructionOperandPattern::Capture(
                     patternImmU16->clone())),
-                2));
+                patternX->clone(),
+                1, 2));
 
         // Instruction encodings.
         const auto encodingImplicit = builtins.createInstructionEncoding(
@@ -614,7 +615,7 @@ namespace wiz {
         // jump / branch instructions
         builtins.createInstruction(InstructionSignature(BranchKind::Goto, 0, {patternAtLeast0, patternImmU16}), encodingPCRelativeI8Operand, InstructionOptions({0x2F}, {1}, {}));
         builtins.createInstruction(InstructionSignature(BranchKind::Goto, 0, {patternAtLeast1, patternImmU16}), encodingU16Operand, InstructionOptions({0x5F}, {1}, {}));
-        builtins.createInstruction(InstructionSignature(BranchKind::Goto, 0, {patternAtLeast0, patternAbsoluteIndexedByXIndirectU16}), encodingU16Operand, InstructionOptions({0x1F}, {1}, {}));
+        builtins.createInstruction(InstructionSignature(BranchKind::Goto, 0, {patternAtLeast0, patternIndirectJumpIndexedByX}), encodingU16Operand, InstructionOptions({0x1F}, {1}, {}));
         builtins.createInstruction(InstructionSignature(BranchKind::Goto, 0, {patternAtLeast0, patternImmU16, patternCarry, patternFalse}), encodingPCRelativeI8Operand, InstructionOptions({0x90}, {1}, {}));
         builtins.createInstruction(InstructionSignature(BranchKind::Goto, 0, {patternAtLeast0, patternImmU16, patternCarry, patternTrue}), encodingPCRelativeI8Operand, InstructionOptions({0xB0}, {1}, {}));
         builtins.createInstruction(InstructionSignature(BranchKind::Goto, 0, {patternAtLeast0, patternImmU16, patternZero, patternFalse}), encodingPCRelativeI8Operand, InstructionOptions({0xD0}, {1}, {}));

--- a/tests/block/spc700_16_bit.wiz
+++ b/tests/block/spc700_16_bit.wiz
@@ -1,0 +1,49 @@
+// SYSTEM  spc700
+//
+// Disassembly created using Mesen-S's Trace Logger
+
+bank zeropage @ 0x000 : [vardata;   0x100];
+bank code     @ 0x200 : [constdata; 0x100];
+
+in zeropage {
+    var _padding1       : [u8; 0x80];
+
+    var zp_u16_80       : u16;          // address = 0x80
+}
+
+
+// BLOCK 0000
+in code {
+
+
+func test() {
+// BLOCK        DA 80       stw $80
+    zp_u16_80 = ya;
+
+// BLOCK        BA 80       ldw $80
+    ya = zp_u16_80;
+
+// BLOCK        3A 80       inw $80
+// BLOCK        3A 80       inw $80
+    zp_u16_80++;
+    ++zp_u16_80;
+
+// BLOCK        1A 80       dew $80
+// BLOCK        1A 80       dew $80
+    zp_u16_80--;
+    --zp_u16_80;
+
+// BLOCK        7A 80       adw $80
+    ya += zp_u16_80;
+
+// BLOCK        9A 80       sbw $80
+    ya -= zp_u16_80;
+
+// BLOCK        5A 80       cpw $80
+    cmp(ya, zp_u16_80);
+
+// BLOCK        6F          rts
+}
+
+}
+

--- a/tests/block/spc700_alu.wiz
+++ b/tests/block/spc700_alu.wiz
@@ -1,0 +1,219 @@
+// SYSTEM  spc700
+//
+// Disassembly created using Mesen-S's Trace Logger
+
+bank zeropage @ 0x000 : [vardata;   0x100];
+bank abs      @ 0x100 : [vardata;   0x100];
+bank code     @ 0x200 : [constdata; 0x100];
+
+in zeropage {
+    var _padding1       : [u8; 0x11];
+
+    var zp_u8_11        : u8;           // address = 0x11
+    var zp_array_12     : [u8; 0x11];   // address = 0x12
+    var zp_ptr_23       : *u8;          // ...
+    var zp_array_ptr_25 : [*u8; 6];
+}
+
+in abs {
+    var _padding2       : [u8; 0x40];
+
+    var abs_u8_140      : u8;
+    var abs_array_141   : [u8; 0x10];
+}
+
+
+// BLOCK 0000
+in code {
+
+func load() {
+
+// BLOCK        60         clc
+// BLOCK        88 01      adc #$01
+// BLOCK        60         clc
+// BLOCK        86         adc (x)
+// BLOCK        60         clc
+// BLOCK        84 11      adc $11
+// BLOCK        60         clc
+// BLOCK        94 12      adc $12,x
+// BLOCK        60         clc
+// BLOCK        85 40 01   adc $0140
+// BLOCK        60         clc
+// BLOCK        95 41 01   adc $0141,x
+// BLOCK        60         clc
+// BLOCK        96 41 01   adc $0141,y
+// BLOCK        60         clc
+// BLOCK        87 25      adc [$25,x]
+// BLOCK        60         clc
+// BLOCK        97 23      adc [$23],y
+    a = a + 1;
+    a = a + *(x as *u8);
+    a = a + zp_u8_11;
+    a = a + zp_array_12[x];
+    a = a + abs_u8_140;
+    a = a + abs_array_141[x];
+    a = a + abs_array_141[y];
+    a = a + *zp_array_ptr_25[unaligned x];
+    a = a + zp_ptr_23[y];
+
+// BLOCK        88 02      adc #$02
+// BLOCK        86         adc (x)
+// BLOCK        84 11      adc $11
+// BLOCK        94 12      adc $12,x
+// BLOCK        85 40 01   adc $0140
+// BLOCK        95 41 01   adc $0141,x
+// BLOCK        96 41 01   adc $0141,y
+// BLOCK        87 25      adc [$25,x]
+// BLOCK        97 23      adc [$23],y
+    a = a +# 2;
+    a = a +# *(x as *u8);
+    a = a +# zp_u8_11;
+    a = a +# zp_array_12[x];
+    a = a +# abs_u8_140;
+    a = a +# abs_array_141[x];
+    a = a +# abs_array_141[y];
+    a = a +# *zp_array_ptr_25[unaligned x];
+    a = a +# zp_ptr_23[y];
+
+// BLOCK        80         sec
+// BLOCK        A8 03      sbc #$03
+// BLOCK        80         sec
+// BLOCK        A6         sbc (x)
+// BLOCK        80         sec
+// BLOCK        A4 11      sbc $11
+// BLOCK        80         sec
+// BLOCK        B4 12      sbc $12,x
+// BLOCK        80         sec
+// BLOCK        A5 40 01   sbc $0140
+// BLOCK        80         sec
+// BLOCK        B5 41 01   sbc $0141,x
+// BLOCK        80         sec
+// BLOCK        B6 41 01   sbc $0141,y
+// BLOCK        80         sec
+// BLOCK        A7 25      sbc [$25,x]
+// BLOCK        80         sec
+// BLOCK        B7 23      sbc [$23],y
+    a = a - 3;
+    a = a - *(x as *u8);
+    a = a - zp_u8_11;
+    a = a - zp_array_12[x];
+    a = a - abs_u8_140;
+    a = a - abs_array_141[x];
+    a = a - abs_array_141[y];
+    a = a - *zp_array_ptr_25[unaligned x];
+    a = a - zp_ptr_23[y];
+
+// BLOCK        A8 04      sbc #$04
+// BLOCK        A6         sbc (x)
+// BLOCK        A4 11      sbc $11
+// BLOCK        B4 12      sbc $12,x
+// BLOCK        A5 40 01   sbc $0140
+// BLOCK        B5 41 01   sbc $0141,x
+// BLOCK        B6 41 01   sbc $0141,y
+// BLOCK        A7 25      sbc [$25,x]
+// BLOCK        B7 23      sbc [$23],y
+    a = a -# 4;
+    a = a -# *(x as *u8);
+    a = a -# zp_u8_11;
+    a = a -# zp_array_12[x];
+    a = a -# abs_u8_140;
+    a = a -# abs_array_141[x];
+    a = a -# abs_array_141[y];
+    a = a -# *zp_array_ptr_25[unaligned x];
+    a = a -# zp_ptr_23[y];
+
+// BLOCK        68 05      cmp #$05
+// BLOCK        66         cmp (x)
+// BLOCK        64 11      cmp $11
+// BLOCK        74 12      cmp $12,x
+// BLOCK        65 40 01   cmp $0140
+// BLOCK        75 41 01   cmp $0141,x
+// BLOCK        76 41 01   cmp $0141,y
+// BLOCK        67 25      cmp [$25,x]
+// BLOCK        77 23      cmp [$23],y
+    cmp(a, 5);
+    cmp(a, *(x as *u8));
+    cmp(a, zp_u8_11);
+    cmp(a, zp_array_12[x]);
+    cmp(a, abs_u8_140);
+    cmp(a, abs_array_141[x]);
+    cmp(a, abs_array_141[y]);
+    cmp(a, *zp_array_ptr_25[unaligned x]);
+    cmp(a, zp_ptr_23[y]);
+
+// BLOCK        C8 06      cpx #$06
+// BLOCK        3E 11      cpx $11
+// BLOCK        1E 40 01   cpx $0140
+    cmp(x, 6);
+    cmp(x, zp_u8_11);
+    cmp(x, abs_u8_140);
+
+// BLOCK        AD 07      cmy #$07
+// BLOCK        7E 11      cpy $11
+// BLOCK        5E 40 01   cpy $0140
+    cmp(y, 7);
+    cmp(y, zp_u8_11);
+    cmp(y, abs_u8_140);
+
+// BLOCK        28 08      and #$08
+// BLOCK        26         and (x)
+// BLOCK        24 11      and $11
+// BLOCK        34 12      and $12,x
+// BLOCK        25 40 01   and $0140
+// BLOCK        35 41 01   and $0141,x
+// BLOCK        36 41 01   and $0141,y
+// BLOCK        27 25      and [$25,x]
+// BLOCK        37 23      and [$23],y
+    a = a & 8;
+    a = a & *(x as *u8);
+    a = a & zp_u8_11;
+    a = a & zp_array_12[x];
+    a = a & abs_u8_140;
+    a = a & abs_array_141[x];
+    a = a & abs_array_141[y];
+    a = a & *zp_array_ptr_25[unaligned x];
+    a = a & zp_ptr_23[y];
+
+// BLOCK        08 09      ora #$09
+// BLOCK        06         ora (x)
+// BLOCK        04 11      ora $11
+// BLOCK        14 12      ora $12,x
+// BLOCK        05 40 01   ora $0140
+// BLOCK        15 41 01   ora $0141,x
+// BLOCK        16 41 01   ora $0141,y
+// BLOCK        07 25      ora [$25,x]
+// BLOCK        17 23      ora [$23],y
+    a = a | 9;
+    a = a | *(x as *u8);
+    a = a | zp_u8_11;
+    a = a | zp_array_12[x];
+    a = a | abs_u8_140;
+    a = a | abs_array_141[x];
+    a = a | abs_array_141[y];
+    a = a | *zp_array_ptr_25[unaligned x];
+    a = a | zp_ptr_23[y];
+
+// BLOCK        48 0A      eor #$0a
+// BLOCK        46         eor (x)
+// BLOCK        44 11      eor $11
+// BLOCK        54 12      eor $12,x
+// BLOCK        45 40 01   eor $0140
+// BLOCK        55 41 01   eor $0141,x
+// BLOCK        56 41 01   eor $0141,y
+// BLOCK        47 25      eor [$25,x]
+// BLOCK        57 23      eor [$23],y
+    a = a ^ 10;
+    a = a ^ *(x as *u8);
+    a = a ^ zp_u8_11;
+    a = a ^ zp_array_12[x];
+    a = a ^ abs_u8_140;
+    a = a ^ abs_array_141[x];
+    a = a ^ abs_array_141[y];
+    a = a ^ *zp_array_ptr_25[unaligned x];
+    a = a ^ zp_ptr_23[y];
+
+// BLOCK        6F         rts
+}
+
+}
+

--- a/tests/block/spc700_cbne_dbnz.wiz
+++ b/tests/block/spc700_cbne_dbnz.wiz
@@ -1,0 +1,91 @@
+// SYSTEM  spc700
+//
+// Disassembly created using Mesen-S's Trace Logger
+
+
+bank zeropage @ 0x000 : [vardata;   0x100];
+bank padding  @ 0x000 : [constdata; 0x200];
+bank code     @ 0x200 : [constdata; 0x100];
+
+
+in zeropage {
+    var _padding        : [u8; 0x40];
+
+    var zp_u8_40        : u8;           // address = 0x40
+    var zp_array_41     : [u8; 5];      // address = 0x41
+}
+
+
+in code {
+
+func test() {
+
+// BLOCK  0200  C4 40      sta $40
+// BLOCK  0202  2E 40 01   cbne $40,$0206
+// BLOCK  0205  00         nop
+    zp_u8_40 = a;
+    if a == zp_u8_40 {
+        nop();
+    }
+
+
+// BLOCK  0206  00         nop
+// BLOCK  0207  2E 40 FC   cbne $40,$0206
+    do {
+        nop();
+    } while a != zp_u8_40;
+
+
+// BLOCK  020A  D4 41      sta $41,x
+// BLOCK  020C  DE 41 01   cbne $41,x, $0210
+// BLOCK  020F  00         nop
+    zp_array_41[x] = a;
+    if a == zp_array_41[x] {
+        nop();
+    }
+
+
+// BLOCK  0210  00         nop
+// BLOCK  0211  DE 41 FC   cbne $41,x, $0210
+    do {
+        nop();
+    } while a != zp_array_41[x];
+
+
+// BLOCK  0214  8D 01      ldy #$01
+// BLOCK  0216  FE 01      dbnz y,$0219
+// BLOCK  0218  00         nop
+    y = 1;
+    if --y == 0 {
+        nop();
+    }
+
+
+// BLOCK  0219  8D 01      ldy #$01
+// BLOCK  021B  FE FC      dbnz y,$0219
+    do {
+        y = 1;
+    } while --y != 0;
+
+
+// BLOCK  021D  8F 01 40   mov $40,#$01
+// BLOCK  0220  6E 40 01   dbnz $40,$0224
+// BLOCK  0223  00         nop
+    zp_u8_40 = 1;
+    if --zp_u8_40 == 0 {
+        nop();
+    }
+
+
+// BLOCK  0224  8F 01 40   mov $40,#$01
+// BLOCK  0227  6E 40 FA   dbnz $40,$0224
+    do {
+        zp_u8_40 = 1;
+    } while --zp_u8_40 != 0;
+
+
+// BLOCK  022A  6F         rts
+}
+
+}
+

--- a/tests/block/spc700_divmod.wiz
+++ b/tests/block/spc700_divmod.wiz
@@ -1,0 +1,20 @@
+// SYSTEM  spc700
+//
+// Disassembly created using Mesen-S's Trace Logger
+
+bank code     @ 0x200 : [constdata; 0x100];
+
+
+// BLOCK 0000
+in code {
+
+func test() {
+
+// BLOCK        9E           div ya,x
+    divmod(ya, x);
+
+// BLOCK        6F           rts
+}
+
+}
+

--- a/tests/block/spc700_dp_dp.wiz
+++ b/tests/block/spc700_dp_dp.wiz
@@ -1,0 +1,94 @@
+// SYSTEM  spc700
+//
+// Disassembly created using Mesen-S's Trace Logger
+
+
+bank zeropage @  0x00 : [vardata;   0x100];
+bank code     @ 0x200 : [constdata; 0x100];
+
+
+in zeropage {
+    var zp_u8_00    : u8;    // address 0x00
+    var zp_u8_01    : u8;    // address 0x01
+    var zp_u8_02    : u8;    // ...
+    var zp_u8_03    : u8;
+    var zp_u8_04    : u8;
+    var zp_u8_05    : u8;
+    var zp_u8_06    : u8;
+    var zp_u8_07    : u8;
+    var zp_u8_08    : u8;
+    var zp_u8_09    : u8;
+    var zp_u8_0a    : u8;
+    var zp_u8_0b    : u8;
+    var zp_u8_0c    : u8;
+    var zp_u8_0d    : u8;
+}
+
+
+// BLOCK 0000
+in code {
+
+func test() {
+
+// BLOCK        FA 01 00   mov $00,$01
+    zp_u8_00 = zp_u8_01;
+
+// BLOCK        60         clc
+// BLOCK        89 02 00   adc $00,$02
+    zp_u8_00 += zp_u8_02;
+
+// BLOCK        89 03 00   adc $00,$03
+    zp_u8_00 +#= zp_u8_03;
+
+// BLOCK        80         sec
+// BLOCK        A9 04 00   sbc $00,$04
+    zp_u8_00 -= zp_u8_04;
+
+// BLOCK        A9 05 00   sbc $00,$05
+    zp_u8_00 -#= zp_u8_05;
+
+// BLOCK        29 06 00   and $00,$06
+    zp_u8_00 &= zp_u8_06;
+
+// BLOCK        09 07 00   or $00,$07
+    zp_u8_00 |= zp_u8_07;
+
+// BLOCK        49 08 00   eor $00,$08
+    zp_u8_00 ^= zp_u8_08;
+
+// BLOCK        69 09 00   cmp $00,$09
+    cmp(zp_u8_00, zp_u8_09);
+
+// BLOCK        69 0A 00   cmp $00,$0a
+// BLOCK        D0 01      bne $0223
+// BLOCK        00         nop
+    if zp_u8_00 == zp_u8_0a {
+        nop();
+    }
+
+// BLOCK        69 0B 00   cmp $00,$0b
+// BLOCK        F0 01      beq $0229
+// BLOCK        00         nop
+    if zp_u8_00 != zp_u8_0b {
+        nop();
+    }
+
+// BLOCK        69 0C 00   cmp $00,$0c
+// BLOCK        B0 01      bcs $022f
+// BLOCK        00         nop
+    if zp_u8_00 < zp_u8_0c {
+        nop();
+    }
+
+// BLOCK        69 0D 00   cmp $00,$0d
+// BLOCK        90 01      bcc $0235
+// BLOCK        00         nop
+    if zp_u8_00 >= zp_u8_0d {
+        nop();
+    }
+
+// BLOCK        6F         rts
+}
+
+}
+

--- a/tests/block/spc700_dp_imm.wiz
+++ b/tests/block/spc700_dp_imm.wiz
@@ -1,0 +1,81 @@
+// SYSTEM  spc700
+//
+// Disassembly created using Mesen-S's Trace Logger
+
+bank zeropage @  0x00 : [vardata;   0x100];
+bank code     @ 0x200 : [constdata; 0x100];
+
+
+in zeropage {
+    var _padding    : [u8; 0x24];
+
+    var zp_u8_24    : u8;    // address 0x24
+}
+
+
+// BLOCK 0000
+in code {
+
+func test() {
+// BLOCK        8F 01 24   mov $24,#$01
+    zp_u8_24 = 1;
+
+// BLOCK        60         clc
+// BLOCK        98 02 24   adc $24,#$02
+    zp_u8_24 += 2;
+
+// BLOCK        98 03 24   adc $24,#$03
+    zp_u8_24 +#= 3;
+
+// BLOCK        80         sec
+// BLOCK        B8 04 24   sbc $24,#$04
+    zp_u8_24 -= 4;
+
+// BLOCK        B8 05 24   sbc $24,#$05
+    zp_u8_24 -#= 5;
+
+// BLOCK        38 06 24   and $24,#$06
+    zp_u8_24 &= 6;
+
+// BLOCK        18 07 24   or $24,#$07
+    zp_u8_24 |= 7;
+
+// BLOCK        58 08 24   eor $24,#$08
+    zp_u8_24 ^= 8;
+
+// BLOCK        78 09 24   cmp $24,#$09
+    cmp(zp_u8_24, 9);
+
+// BLOCK        78 0A 24   cmp $24,#$0a
+// BLOCK        D0 01      bne $0223
+// BLOCK        00         nop
+    if zp_u8_24 == 10 {
+        nop();
+    }
+
+// BLOCK        78 0B 24   cmp $24,#$0b
+// BLOCK        F0 01      beq $0229
+// BLOCK        00         nop
+    if zp_u8_24 != 11 {
+        nop();
+    }
+
+// BLOCK        78 0C 24   cmp $24,#$0c
+// BLOCK        B0 01      bcs $022f
+// BLOCK        00         nop
+    if zp_u8_24 < 12 {
+        nop();
+    }
+
+// BLOCK        78 0D 24   cmp $24,#$0d
+// BLOCK        90 01      bcc $0235
+// BLOCK        00         nop
+    if zp_u8_24 >= 13 {
+        nop();
+    }
+
+// BLOCK        6F         rts
+}
+
+}
+

--- a/tests/block/spc700_if.wiz
+++ b/tests/block/spc700_if.wiz
@@ -1,0 +1,219 @@
+// SYSTEM  spc700
+//
+// Disassembly created using Mesen-S's Trace Logger and Mesen-S's debugger
+
+bank zeropage @ 0x000 : [vardata;   0x100];
+bank padding  @ 0x000 : [constdata; 0x200];
+bank code     @ 0x200 : [constdata; 0x100];
+
+
+in zeropage {
+    var _padding1       : [u8; 0x8F];
+
+    var zp_u8_8f        : u8;           // address = 0x8f
+    var zp_u8_90        : u8;           // address = 0x90
+    var zp_i8_91        : i8;           // address = 0x91
+    var zp_array_92     : [u8; 0x10];   // ...
+}
+
+
+// BLOCK 0000
+in code {
+
+func test() {
+
+// BLOCK  0200  2F 01      bra $0203
+// BLOCK  0202  00         nop
+    goto Label;
+    nop();
+Label:
+
+
+// BLOCK  0203  D0 01      bne $0206
+// BLOCK  0205  00         nop
+    if zero {
+        nop();
+    }
+
+// BLOCK  0206  F0 01      beq $0209
+// BLOCK  0208  00         nop
+    if !zero {
+        nop();
+    }
+
+// BLOCK  0209  90 01      bcc $020c
+// BLOCK  020B  00         nop
+    if carry {
+        nop();
+    }
+
+// BLOCK  020C  B0 01      bcs $020f
+// BLOCK  020E  00         nop
+    if !carry {
+        nop();
+    }
+
+// BLOCK  020F  50 01      bvc $0212
+// BLOCK  0211  00         nop
+    if overflow {
+        nop();
+    }
+
+// BLOCK  0212  70 01      bvs $0215
+// BLOCK  0214  00         nop
+    if !overflow {
+        nop();
+    }
+
+// BLOCK  0215  10 01      bpl $0218
+// BLOCK  0217  00         nop
+    if negative {
+        nop();
+    }
+
+// BLOCK  0218  30 01      bmi $021b
+// BLOCK  021A  00         nop
+    if !negative {
+        nop();
+    }
+
+
+// BLOCK  021B  68 01      cmp #$01
+// BLOCK  021D  D0 01      bne $0220
+// BLOCK  021F  00         nop
+    if a == 1 {
+        nop();
+    }
+
+// BLOCK  0220  68 02      cmp #$02
+// BLOCK  0222  F0 01      beq $0225
+// BLOCK  0224  00         nop
+    if a != 2 {
+        nop();
+    }
+
+// BLOCK  0225  68 03      cmp #$03
+// BLOCK  0227  B0 01      bcs $022a
+// BLOCK  0229  00         nop
+    if a < 3 {
+        nop();
+    }
+
+// BLOCK  022A  68 04      cmp #$04
+// BLOCK  022C  F0 02      beq $0230
+// BLOCK  022E  B0 01      bcs $0231
+// BLOCK  0230  00         nop
+    if a <= 4 {
+        nop();
+    }
+
+// BLOCK  0231  68 05      cmp #$05
+// BLOCK  0233  F0 03      beq $0238
+// BLOCK  0235  90 01      bcc $0238
+// BLOCK  0237  00         nop
+    if a > 5 {
+        nop();
+    }
+
+// BLOCK  0238  68 06      cmp #$06
+// BLOCK  023A  90 01      bcc $023d
+// BLOCK  023C  00         nop
+    if a >= 6 {
+        nop();
+    }
+
+
+// BLOCK  023D  78 00 91   cmp $91,#$00
+// BLOCK  0240  10 01      bpl $0243
+// BLOCK  0242  00         nop
+    if zp_i8_91 < 0 {
+        nop();
+    }
+
+// BLOCK  0243  78 00 91   cmp $91,#$00
+// BLOCK  0246  30 01      bmi $0249
+// BLOCK  0248  00         nop
+    if zp_i8_91 >= 0 {
+        nop();
+    }
+
+// BLOCK  0249  78 00 91   cmp $91,#$00
+// BLOCK  024C  F0 03      beq $0251
+// BLOCK  024E  30 01      bmi $0251
+// BLOCK  0250  00         nop
+    if zp_i8_91 > 0 {
+        nop();
+    }
+
+// BLOCK  0251  78 00 91   cmp $91,#$00
+// BLOCK  0254  F0 02      beq $0258
+// BLOCK  0256  10 01      bpl $0259
+// BLOCK  0258  00         nop
+    if zp_i8_91 <= 0 {
+        nop();
+    }
+
+
+// BLOCK  0259  78 01 90   cmp $90,#$01
+// BLOCK  025C  D0 01      bne $025f
+// BLOCK  025E  00         nop
+    if zp_u8_90 == 1 {
+        nop();
+    }
+
+// BLOCK  025F  78 02 90   cmp $90,#$02
+// BLOCK  0262  F0 01      beq $0265
+// BLOCK  0264  00         nop
+    if zp_u8_90 != 2 {
+        nop();
+    }
+
+// BLOCK  0265  78 03 90   cmp $90,#$03
+// BLOCK  0268  B0 01      bcs $026b
+// BLOCK  026A  00         nop
+    if zp_u8_90 < 3 {
+        nop();
+    }
+
+// BLOCK  026B  78 04 90   cmp $90,#$04
+// BLOCK  026E  90 01      bcc $0271
+// BLOCK  0270  00         nop
+    if zp_u8_90 >= 4 {
+        nop();
+    }
+
+
+// BLOCK  0271  69 90 8F   cmp $8f,$90
+// BLOCK  0274  D0 01      bne $0277
+// BLOCK  0276  00         nop
+    if zp_u8_8f == zp_u8_90 {
+        nop();
+    }
+
+// BLOCK  0277  69 90 8F   cmp $8f,$90
+// BLOCK  027A  F0 01      beq $027d
+// BLOCK  027C  00         nop
+    if zp_u8_8f != zp_u8_90 {
+        nop();
+    }
+
+// BLOCK  027D  69 90 8F   cmp $8f,$90
+// BLOCK  0280  B0 01      bcs $0283
+// BLOCK  0282  00         nop
+    if zp_u8_8f < zp_u8_90 {
+        nop();
+    }
+
+// BLOCK  0283  69 90 8F   cmp $8f,$90
+// BLOCK  0286  90 01      bcc $0289
+// BLOCK  0288  00         nop
+    if zp_u8_8f >= zp_u8_90 {
+        nop();
+    }
+
+
+// BLOCK  0289  6F         rts
+}
+
+}
+

--- a/tests/block/spc700_inc_dec.wiz
+++ b/tests/block/spc700_inc_dec.wiz
@@ -1,0 +1,101 @@
+// SYSTEM  spc700
+//
+// Disassembly created using Mesen-S's Trace Logger
+
+bank zeropage @ 0x000 : [vardata;   0x100];
+bank abs      @ 0x100 : [vardata;   0x100];
+bank code     @ 0x200 : [constdata; 0x100];
+
+in zeropage {
+    var _padding1       : [u8; 0x40];
+
+    var zp_u8_40        : u8;           // address = 0x40
+    var zp_u16_41       : u16;          // address = 0x41
+    var zp_array_43     : [u8; 0x10];   // ...
+}
+
+in abs {
+    var _padding2       : [u8; 0x50];
+
+    var abs_u8_150      : u8;
+}
+
+
+// BLOCK 0000
+in code {
+
+func test() {
+
+// BLOCK        BC         inc a
+// BLOCK        3D         inx
+// BLOCK        FC         inc y
+    a++;
+    x++;
+    y++;
+
+// BLOCK        AB 40      inc $40
+// BLOCK        BB 43      inc $43,x
+// BLOCK        AC 50 01   inc $0150
+    zp_u8_40++;
+    zp_array_43[x]++;
+    abs_u8_150++;
+
+// BLOCK        BC         inc a
+// BLOCK        3D         inx
+// BLOCK        FC         inc y
+    ++a;
+    ++x;
+    ++y;
+
+// BLOCK        AB 40      inc $40
+// BLOCK        BB 43      inc $43,x
+// BLOCK        AC 50 01   inc $0150
+    ++zp_u8_40;
+    ++zp_array_43[x];
+    ++abs_u8_150;
+
+// BLOCK        3A 41      inw $41
+// BLOCK        3A 41      inw $41
+    zp_u16_41++;
+    ++zp_u16_41;
+
+
+// BLOCK        9C         dec a
+// BLOCK        1D         dex
+// BLOCK        DC         dey
+    a--;
+    x--;
+    y--;
+
+// BLOCK        8B 40      dec $40
+// BLOCK        9B 43      dec $43,x
+// BLOCK        8C 50 01   dec $0150
+    zp_u8_40--;
+    zp_array_43[x]--;
+    abs_u8_150--;
+
+// BLOCK        9C         dec a
+// BLOCK        1D         dex
+// BLOCK        DC         dey
+    --a;
+    --x;
+    --y;
+
+// BLOCK        8B 40      dec $40
+// BLOCK        9B 43      dec $43,x
+// BLOCK        8C 50 01   dec $0150
+    --zp_u8_40;
+    --zp_array_43[x];
+    --abs_u8_150;
+
+// BLOCK        1A 41      dew $41
+// BLOCK        1A 41      dew $41
+    zp_u16_41--;
+    --zp_u16_41;
+
+
+// BLOCK        6F         rts
+}
+
+}
+

--- a/tests/block/spc700_indirect_x_y.wiz
+++ b/tests/block/spc700_indirect_x_y.wiz
@@ -1,0 +1,43 @@
+// SYSTEM  spc700
+//
+// Disassembly created using Mesen-S's Trace Logger
+
+bank code     @ 0x200 : [constdata; 0x100];
+
+
+// BLOCK 0000
+in code {
+
+func test() {
+
+// BLOCK        60           clc
+// BLOCK        99           adc (x),(y)
+    *(x as *u8) += *(y as *u8);
+
+// BLOCK        99           adc (x),(y)
+    *(x as *u8) +#= *(y as *u8);
+
+// BLOCK        80           sec
+// BLOCK        B9           sbc (x),(y)
+    *(x as *u8) -= *(y as *u8);
+
+// BLOCK        B9           sbc (x),(y)
+    *(x as *u8) -#= *(y as *u8);
+
+// BLOCK        39           and (x),(y)
+    *(x as *u8) &= *(y as *u8);
+
+// BLOCK        19           or (x),(y)
+    *(x as *u8) |= *(y as *u8);
+
+// BLOCK        59           eor (x),(y)
+    *(x as *u8) ^= *(y as *u8);
+
+// BLOCK        79           cmp (x),(y)
+    cmp(*(x as *u8), *(y as *u8));
+
+// BLOCK        6F           rts
+}
+
+}
+

--- a/tests/block/spc700_jump_indirect.wiz
+++ b/tests/block/spc700_jump_indirect.wiz
@@ -1,0 +1,35 @@
+// SYSTEM  spc700
+//
+// Disassembly manually created
+
+bank code     @ 0x200 : [constdata; 0x100];
+
+
+// BLOCK 0000
+in code {
+
+// BLOCK        04 02
+// BLOCK        04 02
+const func_table = [
+    test,
+    test,
+];
+
+func test() {
+
+// BLOCK        1F 00 02    JMP [!abs+X]
+    goto *((&func_table as u16 + x as u16) as *func);
+
+// BLOCK        1F 00 02    JMP [!abs+X]
+// BLOCK        1F 00 02    JMP [!abs+X]
+    goto func_table[unaligned x];
+    ^goto func_table[unaligned x];
+
+// BLOCK        1F 00 02    JMP [!abs+X]
+// BLOCK        1F 00 02    JMP [!abs+X]
+    return func_table[unaligned x]();
+    ^return func_table[unaligned x]();
+}
+
+}
+

--- a/tests/block/spc700_load_store.wiz
+++ b/tests/block/spc700_load_store.wiz
@@ -1,0 +1,109 @@
+// SYSTEM  spc700
+//
+// Disassembly created using Mesen-S's Trace Logger
+
+bank zeropage @ 0x000 : [vardata;   0x100];
+bank abs      @ 0x100 : [vardata;   0x100];
+bank code     @ 0x200 : [constdata; 0x100];
+
+in zeropage {
+    var _padding1       : [u8; 0x11];
+
+    var zp_u8_11        : u8;           // address = 0x11
+    var zp_array_12     : [u8; 0x11];   // address = 0x12
+    var zp_ptr_23       : *u8;          // ...
+    var zp_array_ptr_25 : [*u8; 6];
+}
+
+in abs {
+    var _padding2       : [u8; 0x40];
+
+    var abs_u8_140      : u8;
+    var abs_array_141   : [u8; 0x10];
+}
+
+
+// BLOCK 0000
+in code {
+
+func test() {
+
+// BLOCK        E8 16      lda #$16
+// BLOCK        E6         lda (x)
+// BLOCK        BF         lda (x)+
+// BLOCK        E4 11      lda $11
+// BLOCK        F4 12      lda $12,x
+// BLOCK        E5 40 01   lda $0140
+// BLOCK        F5 41 01   lda $0141,x
+// BLOCK        F6 41 01   lda $0141,y
+// BLOCK        E7 25      lda [$25,x]
+// BLOCK        F7 23      lda [$23],y
+    a = 22;
+    a = *(x as *u8);
+    a = *(x as *u8)++;
+    a = zp_u8_11;
+    a = zp_array_12[x];
+    a = abs_u8_140;
+    a = abs_array_141[x];
+    a = abs_array_141[y];
+    a = *zp_array_ptr_25[unaligned x];
+    a = zp_ptr_23[y];
+
+// BLOCK        CD 21      ldx #$21
+// BLOCK        F8 11      ldx $11
+// BLOCK        F9 12      ldx $12,y
+// BLOCK        E9 40 01   ldx $0140
+    x = 33;
+    x = zp_u8_11;
+    x = zp_array_12[y];
+    x = abs_u8_140;
+
+// BLOCK        8D 2C      ldy #$2c
+// BLOCK        EB 11      ldy $11
+// BLOCK        FB 12      ldy $12,x
+// BLOCK        EC 40 01   ldy $0140
+    y = 44;
+    y = zp_u8_11;
+    y = zp_array_12[x];
+    y = abs_u8_140;
+
+
+// BLOCK        C6         sta (x)
+// BLOCK        AF         sta (x)+,a
+// BLOCK        C4 11      sta $11
+// BLOCK        D4 12      sta $12,x
+// BLOCK        C5 40 01   sta $0140
+// BLOCK        D5 41 01   sta $0141,x
+// BLOCK        D6 41 01   sta $0141,y
+// BLOCK        C7 25      sta [$25,x]
+// BLOCK        D7 23      sta [$23],y
+    *(x as *u8) = a;
+    *(x as *u8)++ = a;
+    zp_u8_11 = a;
+    zp_array_12[x] = a;
+    abs_u8_140 = a;
+    abs_array_141[x] = a;
+    abs_array_141[y] = a;
+    *zp_array_ptr_25[unaligned x] = a;
+    zp_ptr_23[y] = a;
+
+// BLOCK        D8 11      stx $11
+// BLOCK        D9 12      stx $12,y
+// BLOCK        C9 40 01   stx $0140
+    zp_u8_11 = x;
+    zp_array_12[y] = x;
+    abs_u8_140 = x;
+
+// BLOCK        CB 11      sty $11
+// BLOCK        DB 12      sty $12,x
+// BLOCK        CC 40 01   sty $0140
+    zp_u8_11 = y;
+    zp_array_12[x] = y;
+    abs_u8_140 = y;
+
+
+// BLOCK        6F         rts
+}
+
+}
+

--- a/tests/block/spc700_memory_bit_operations.wiz
+++ b/tests/block/spc700_memory_bit_operations.wiz
@@ -1,0 +1,107 @@
+// SYSTEM  spc700
+//
+// Disassembly created using Mesen-S's Trace Logger
+
+bank zeropage @ 0x000 : [vardata;   0x100];
+bank abs      @ 0x100 : [vardata;   0x100];
+bank code     @ 0x200 : [constdata; 0x100];
+
+in zeropage {
+    var _padding1 : [u8; 0x12];
+
+    var zp_u8_12 : u8; // address = 0x12
+}
+
+in abs {
+    var _padding2 : u8;
+
+    var abs_u8_101 : u8; // address = 0x101
+}
+
+
+// BLOCK 0000
+in code {
+
+func test() {
+
+// BLOCK        02 12      set1 $12.0
+// BLOCK        22 12      set1 $12.1
+// BLOCK        42 12      set1 $12.2
+// BLOCK        62 12      set1 $12.3
+// BLOCK        82 12      set1 $12.4
+// BLOCK        A2 12      set1 $12.5
+// BLOCK        C2 12      set1 $12.6
+// BLOCK        E2 12      set1 $12.7
+    zp_u8_12 $ 0 = true;
+    zp_u8_12 $ 1 = true;
+    zp_u8_12 $ 2 = true;
+    zp_u8_12 $ 3 = true;
+    zp_u8_12 $ 4 = true;
+    zp_u8_12 $ 5 = true;
+    zp_u8_12 $ 6 = true;
+    zp_u8_12 $ 7 = true;
+
+// BLOCK        12 12      clr1 $12.0
+// BLOCK        32 12      clr1 $12.1
+// BLOCK        52 12      clr1 $12.2
+// BLOCK        72 12      clr1 $12.3
+// BLOCK        92 12      clr1 $12.4
+// BLOCK        B2 12      clr1 $12.5
+// BLOCK        D2 12      clr1 $12.6
+// BLOCK        F2 12      clr1 $12.7
+    zp_u8_12 $ 0 = false;
+    zp_u8_12 $ 1 = false;
+    zp_u8_12 $ 2 = false;
+    zp_u8_12 $ 3 = false;
+    zp_u8_12 $ 4 = false;
+    zp_u8_12 $ 5 = false;
+    zp_u8_12 $ 6 = false;
+    zp_u8_12 $ 7 = false;
+
+
+// BLOCK        4A 12 20   andc $0012.1
+// BLOCK        4A 01 41   andc $0101.2
+    carry &= zp_u8_12 $ 1;
+    carry = carry & abs_u8_101 $ 2;
+
+// BLOCK        6A 12 60   andc /$0012.3
+// BLOCK        6A 01 81   andc /$0101.4
+    carry &= !(zp_u8_12 $ 3);
+    carry = carry & !(abs_u8_101 $ 4);
+
+// BLOCK        0A 12 A0   orc $0012.5
+// BLOCK        0A 01 C1   orc $0101.6
+    carry |= zp_u8_12 $ 5;
+    carry = carry | abs_u8_101 $ 6;
+
+// BLOCK        2A 12 E0   orc /$0012.7
+// BLOCK        2A 01 01   orc /$0101.0
+    carry |= !(zp_u8_12 $ 7);
+    carry = carry | !(abs_u8_101 $ 0);
+
+// BLOCK        8A 12 20   eorc $0012.1
+// BLOCK        8A 01 41   eorc $0101.2
+    carry ^= zp_u8_12 $ 1;
+    carry = carry ^ abs_u8_101 $ 2;
+
+// BLOCK        EA 12 60   not $0012.3
+// BLOCK        EA 01 81   not $0101.4
+    zp_u8_12 $ 3 = !zp_u8_12 $ 3;
+    abs_u8_101 $ 4 = !abs_u8_101 $ 4;
+
+// BLOCK        AA 12 A0   ldc $0012.5
+// BLOCK        AA 01 C1   ldc $0101.6
+    carry = zp_u8_12 $ 5;
+    carry = abs_u8_101 $ 6;
+
+// BLOCK        CA 12 E0   stc $0012.7
+// BLOCK        CA 01 01   stc $0101.0
+    zp_u8_12 $ 7 = carry;
+    abs_u8_101 $ 0 = carry;
+
+
+// BLOCK        6F         rts
+}
+
+}
+

--- a/tests/block/spc700_misc.wiz
+++ b/tests/block/spc700_misc.wiz
@@ -1,0 +1,31 @@
+// SYSTEM  spc700
+//
+// Disassembly created using Mesen-S's Trace Logger
+
+bank code     @ 0x200 : [constdata; 0x100];
+
+
+// BLOCK 0000
+in code {
+
+func test() {
+// BLOCK        DF           daa a
+    decimal_adjust_add();
+
+// BLOCK        BE           das a
+    decimal_adjust_sub();
+
+// BLOCK        00           nop
+    nop();
+
+// BLOCK        EF           wai
+    sleep();
+
+// BLOCK        FF           stp
+    stop();
+
+// BLOCK        6F           rts
+}
+
+}
+

--- a/tests/block/spc700_shift.wiz
+++ b/tests/block/spc700_shift.wiz
@@ -1,0 +1,88 @@
+// SYSTEM  spc700
+//
+// Disassembly created using Mesen-S's Trace Logger
+
+bank zeropage @ 0x000 : [vardata;   0x100];
+bank abs      @ 0x100 : [vardata;   0x100];
+bank code     @ 0x200 : [constdata; 0x100];
+
+in zeropage {
+    var _padding1       : [u8; 0x40];
+
+    var zp_u8_40        : u8;           // address = 0x40
+    var zp_array_41     : [u8; 0x10];   // ...
+}
+
+in abs {
+    var _padding2       : [u8; 0x50];
+
+    var abs_u8_150      : u8;
+}
+
+
+// BLOCK 0000
+in code {
+
+func test() {
+
+// BLOCK        1C         asl a
+// BLOCK        1C         asl a
+// BLOCK        1C         asl a
+    a <<= 3;
+
+// BLOCK        00         nop
+    nop();
+
+// BLOCK        1C         asl a
+// BLOCK        0B 40      asl $40
+// BLOCK        1B 41      asl $41,x
+// BLOCK        0C 50 01   asl $0150
+    a <<= 1;
+    zp_u8_40 <<= 1;
+    zp_array_41[x] <<= 1;
+    abs_u8_150 <<= 1;
+
+// BLOCK        1C         asl a
+// BLOCK        0B 40      asl $40
+// BLOCK        1B 41      asl $41,x
+// BLOCK        0C 50 01   asl $0150
+    a <<<= 1;
+    zp_u8_40 <<<= 1;
+    zp_array_41[x] <<<= 1;
+    abs_u8_150 <<<= 1;
+
+// BLOCK        5C         lsr a
+// BLOCK        4B 40      lsr $40
+// BLOCK        5B 41      lsr $41,x
+// BLOCK        4C 50 01   lsr $0150
+    a >>>= 1;
+    zp_u8_40 >>>= 1;
+    zp_array_41[x] >>>= 1;
+    abs_u8_150 >>>= 1;
+
+// BLOCK        3C         rol a
+// BLOCK        2B 40      rol $40
+// BLOCK        3B 41      rol $41,x
+// BLOCK        2C 50 01   rol $0150
+    a <<<<#= 1;
+    zp_u8_40 <<<<#= 1;
+    zp_array_41[x] <<<<#= 1;
+    abs_u8_150 <<<<#= 1;
+
+// BLOCK        7C         ror a
+// BLOCK        6B 40      ror $40
+// BLOCK        7B 41      ror $41,x
+// BLOCK        6C 50 01   ror $0150
+    a >>>>#= 1;
+    zp_u8_40 >>>>#= 1;
+    zp_array_41[x] >>>>#= 1;
+    abs_u8_150 >>>>#= 1;
+
+// BLOCK        9F         xcn a
+    swap_digits(a);
+
+// BLOCK        6F         rts
+}
+
+}
+

--- a/tests/block/spc700_stack.wiz
+++ b/tests/block/spc700_stack.wiz
@@ -1,0 +1,41 @@
+// SYSTEM  spc700
+//
+// Disassembly created using Mesen-S's Trace Logger
+
+bank code     @ 0x200 : [constdata; 0x100];
+
+
+// BLOCK 0000
+in code {
+
+func test() {
+
+// BLOCK        9D           tsx
+    x = sp;
+
+// BLOCK        BD           txs
+    sp = x;
+
+// BLOCK        2D           pha
+// BLOCK        4D           phx
+// BLOCK        6D           phy
+// BLOCK        0D           php
+    push(a);
+    push(x);
+    push(y);
+    push(psw);
+
+// BLOCK        AE           pla
+// BLOCK        CE           plx
+// BLOCK        EE           ply
+// BLOCK        8E           plp
+    a = pop();
+    x = pop();
+    y = pop();
+    psw = pop();
+
+// BLOCK        6F           rts
+}
+
+}
+

--- a/tests/block/spc700_status_flags.wiz
+++ b/tests/block/spc700_status_flags.wiz
@@ -1,0 +1,41 @@
+// SYSTEM  spc700
+//
+// Disassembly created using Mesen-S's Trace Logger
+
+bank code     @ 0x200 : [constdata; 0x100];
+
+
+// BLOCK 0000
+in code {
+
+
+func test() {
+// BLOCK        60           clc
+    carry = false;
+
+// BLOCK        80           sec
+    carry = true;
+
+// BLOCK        ED           notc
+    carry = !carry;
+
+// BLOCK        E0           clv
+    overflow = false;
+
+// BLOCK        20           clp
+    direct_page = false;
+
+// BLOCK        40           sep
+    direct_page = true;
+
+// BLOCK        C0           sei
+    interrupt = false;
+
+// BLOCK        A0           cli
+    interrupt = true;
+
+// BLOCK        6F           rts
+}
+
+}
+

--- a/tests/block/spc700_subroutines.wiz
+++ b/tests/block/spc700_subroutines.wiz
@@ -1,0 +1,55 @@
+// SYSTEM  spc700
+//
+// Disassembly created using Mesen-S's Trace Logger and Mesen-S's SPC Debugger
+
+bank code     @ 0x200 : [constdata; 0x100];
+
+let func_ff20 = 0xff20 as func();
+let func_ff40 = 0xff40 as func();
+
+extern const func_table_ffc0 @ 0xffc0 : [func(); 16];
+
+
+// BLOCK 0000
+in code {
+
+func test() {
+// BLOCK        2F FE      bra $0200
+// BLOCK        2F FC      bra $0200
+    goto test;
+    return test();
+
+// BLOCK        5F 00 02   jmp $0200
+// BLOCK        5F 00 02   jmp $0200
+    ^goto test;
+    ^return test();
+
+// BLOCK        3F 00 02   jsr $0200
+    test();
+
+// BLOCK        4F 20      jsp u
+// BLOCK        4F 40      jsp u
+    func_ff20();
+    func_ff40();
+
+// BLOCK        F1         jstf
+// BLOCK        71         jst7
+// BLOCK        01         jst0
+    func_table_ffc0[0]();
+    func_table_ffc0[8]();
+    func_table_ffc0[15]();
+
+// BLOCK        0F         brk
+    irqcall();
+
+// BLOCK        6F         rts
+}
+
+
+#[irq]
+func irq_handler() {
+// BLOCK        7F         rti
+}
+
+}
+

--- a/tests/block/spc700_tset1_tclr1.wiz
+++ b/tests/block/spc700_tset1_tclr1.wiz
@@ -1,0 +1,27 @@
+// SYSTEM  spc700
+//
+// Disassembly created using Mesen-S's Trace Logger
+
+bank abs      @ 0x100 : [vardata;   0x100];
+bank code     @ 0x200 : [constdata; 0x100];
+
+in abs {
+    var abs_u8_100 : u8; // address = 0x100
+}
+
+
+// BLOCK 0000
+in code {
+
+func test() {
+// BLOCK        0E 00 01   set1 $0100
+    test_and_set(a, abs_u8_100);
+
+// BLOCK        4E 00 01   clr1 $0100
+    test_and_clear(a, abs_u8_100);
+
+// BLOCK        6F         rts
+}
+
+}
+


### PR DESCRIPTION
While coding a SNES audio driver in wiz I noticed some SPC700 statements were miscompiling or causing segfaults.

Over the last few days I have been testing the SPC700 platform, fixing bugs where I can.  Each test has been manually verified by running it through Mesen-S's SPC Debugger and Trace Logger.
