### PR TITLE
Fix building on MSYS2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,16 @@ ifndef PREFIX
 	PREFIX := /usr/local
 endif
 
-ifeq ($(OS),Windows_NT)
+ifeq '$(findstring ;,$(PATH))' ';'
+	UNAME := Windows
+else
+	UNAME := $(shell uname 2>/dev/null || echo Unknown)
+	UNAME := $(patsubst CYGWIN%,Cygwin,$(UNAME))
+	UNAME := $(patsubst MSYS%,MSYS,$(UNAME))
+	UNAME := $(patsubst MINGW%,MSYS,$(UNAME))
+endif
+
+ifeq ($(UNAME),Windows)
 	EXE := .exe
 	LOCATE_COMMAND := makefile_find_command
 else


### PR DESCRIPTION
MSYS2 runs on Windows, but is a UNIX-like environment.  It does not need batch files to find GNU make, etc.; these are natively available.

For once, something useful from StackOverflow: https://stackoverflow.com/a/52062069